### PR TITLE
Drop `Impact` section on bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,9 +10,6 @@ assignees: ''
 ### Problem
 A clear and concise description of what the bug is.
 
-### Impact
-Indicate how significant you believe the impact of the bug is. Bugs that lead to data loss or corruption would be considered `critical`. In such cases, please also add the `critical` label.
-
 ### To reproduce
 If you can reproduce the behaviour, steps to reproduce:
 1. Go to '...'


### PR DESCRIPTION
# Description
I think we should not encourage people to estimate the severity of the bugs they report. I think estimating the severity adequately is not trivial if you are lacking context because you are "just" an external contributor.
When some external contributor creates a bug report I would the team estimate and set the severity on their behalf while keeping an eye on new issues.

If we instead want to continue encouraging users to set the severity I would suggest agreeing on a set of labels and listing all of them here. (Or have something like a prefix so people see all values when searching for it: `S-critical`, `S-high`, `S-medium`, `S-low`)
We should then also have guidelines for each severity to help people make an informed decision.

# Changes
- dropped the `Impact` section in the bug report template